### PR TITLE
Lesson setup

### DIFF
--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -1,11 +1,11 @@
 class Lesson < ApplicationRecord
-	validates :name, presence: true
-	validate :name_contains_only_letters_and_numbers
-	belongs_to :company
+  validates :name, presence: true
+  validate :name_contains_only_letters_and_numbers
+  belongs_to :company
 
-	def name_contains_only_letters_and_numbers
-		if !(self.name =~ /^[a-zA-Z0-9]+$/)
-			errors.add(:name_content, "must only include letters and numbers")
-		end
-	end
+  def name_contains_only_letters_and_numbers
+    if !(self.name =~ /^[a-zA-Z0-9]+$/)
+      errors.add(:name_content, "must only include letters and numbers")
+    end
+  end
 end

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -1,0 +1,11 @@
+class Lesson < ApplicationRecord
+	validates :name, presence: true
+	validate :name_contains_only_letters_and_numbers
+	belongs_to :company
+
+	def name_contains_only_letters_and_numbers
+		if !(self.name =~ /^[a-zA-Z0-9]+$/)
+			errors.add(:name_content, "must only include letters and numbers")
+		end
+	end
+end

--- a/db/migrate/20170912145326_create_lessons.rb
+++ b/db/migrate/20170912145326_create_lessons.rb
@@ -1,0 +1,11 @@
+class CreateLessons < ActiveRecord::Migration[5.1]
+  def change
+    create_table :lessons do |t|
+    	t.string :name
+    	t.references :company
+    	t.boolean :active
+
+    	t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170912134755) do
+ActiveRecord::Schema.define(version: 20170912145326) do
 
   create_table "companies", force: :cascade do |t|
     t.string "name"
@@ -18,6 +18,15 @@ ActiveRecord::Schema.define(version: 20170912134755) do
     t.integer "plan_level"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "lessons", force: :cascade do |t|
+    t.string "name"
+    t.integer "company_id"
+    t.boolean "active"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["company_id"], name: "index_lessons_on_company_id"
   end
 
 end

--- a/spec/models/lesson_spec.rb
+++ b/spec/models/lesson_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+describe Lesson do
+  context "validations" do
+    it { is_expected.to validate_presence_of(:name) }
+
+    it "only allows letters and numbers in the name" do
+    	company = Company.create(name: "Penelope's Shop", plan_level: "legacy")
+    	lesson = Lesson.new(name: "12xc12", company: company)
+    	expect(lesson).to be_valid
+    end
+
+    it "does not allow special characters in the name" do
+    	company = Company.create(name: "Penelope's Shop", plan_level: "legacy")
+    	lesson = Lesson.new(name: "@12x@c12", company: company)
+    	expect(lesson).to be_invalid
+    end
+
+    it "does not allow white spaces in the name" do
+    	company = Company.create(name: "Penelope's Shop", plan_level: "legacy")
+    	lesson = Lesson.new(name: "@12  c12", company: company)
+    	expect(lesson).to be_invalid
+    end
+  end
+
+  context "associations" do
+    it { is_expected.to belong_to(:company) }
+  end
+end


### PR DESCRIPTION
This PR accomplishes the following:

* Adds a `lessons` table with the following attributes:
  - `name`: string
  - `company_id`: integer
  - `active`: boolean
* Adds a `Lesson` model
* Validates that `name` is present on a `Lesson`
* Creates a `belongs_to` association between `Lesson` and `Company` (a lesson belongs to a company)
* Validates that a `Lesson`'s name contains only numbers and letters
* Adds model specs for `Lesson`