### PR TITLE
Add Companies index endpoint and spec

### DIFF
--- a/app/controllers/api/v1/companies_controller.rb
+++ b/app/controllers/api/v1/companies_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::CompaniesController < ApplicationController
+  def index
+    companies = Company.all
+    render json: {companies: companies}
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,8 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+
+  namespace :api do
+    namespace :v1 do
+      resources :companies, only: [:index]
+    end
+  end
 end

--- a/spec/requests/api/v1/companies_controller_spec.rb
+++ b/spec/requests/api/v1/companies_controller_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+describe "CompaniesController" do
+
+  describe "GET /api/v1/companies" do
+    it "returns a list of companies" do
+      company = Company.create!(name: "Penelope's Shop", plan_level: "enterprise")
+
+      get "/api/v1/companies"
+
+      parsed_response = JSON.parse(response.body)
+      expect(parsed_response["companies"].length).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
This PR accomplishes the following:

* Defines an endpoint for `/api/v1/companies` that points to the `Api::V1::CompaniesController`'s `index` action
* Creates the `Api::V1::CompaniesController` and defines an `index` route that returns all `companies` as JSON
* Writes a request spec for this endpoint