### PR TITLE
Add sort companies alphabetically endpoint, Company sorting method, specs

### DIFF
--- a/app/controllers/api/v1/companies_controller.rb
+++ b/app/controllers/api/v1/companies_controller.rb
@@ -3,4 +3,9 @@ class Api::V1::CompaniesController < ApplicationController
     companies = Company.all
     render json: {companies: companies}
   end
+
+  def alphabetically
+    companies = Company.sort_alphabetically
+    render json: {companies: companies}
+  end
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -4,4 +4,8 @@ class Company < ApplicationRecord
   validates :plan_level, inclusion: { in: PLAN_LEVELS}
 
   enum plan_level: PLAN_LEVELS
+
+  def self.sort_alphabetically
+    order(:name)
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :companies, only: [:index]
+      get "/companies/alphabetically" => "companies#alphabetically"
     end
   end
 end

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -4,4 +4,14 @@ describe Company do
   context "validations" do
     it { is_expected.to define_enum_for(:plan_level).with([:legacy, :custom, :basic, :plus, :growth, :enterprise]) }
   end
+
+  describe ".sort_alphabetically" do
+    it "returns a list of companies sorted alphabetically by name" do
+      penelope = Company.create!(name: "Penelope's", plan_level: "enterprise")
+      abc = Company.create!(name: "ABC's", plan_level: "enterprise")
+      zebra = Company.create!(name: "Zebra Company", plan_level: "enterprise")
+
+      expect(Company.sort_alphabetically).to eq([abc, penelope, zebra])
+    end
+  end
 end

--- a/spec/requests/api/v1/companies_controller_spec.rb
+++ b/spec/requests/api/v1/companies_controller_spec.rb
@@ -8,8 +8,23 @@ describe "CompaniesController" do
 
       get "/api/v1/companies"
 
+      expect(response).to be_success
       parsed_response = JSON.parse(response.body)
       expect(parsed_response["companies"].length).to eq(1)
+    end
+  end
+
+  describe "GET /api/v1/companies/alphabetically" do
+    it "returns a list of companies sorted alphabetically by name" do
+      penelope = Company.create!(name: "Penelope's Shop", plan_level: "enterprise")
+      abc = Company.create!(name: "ABC's Shop", plan_level: "enterprise")
+
+      get "/api/v1/companies/alphabetically"
+
+      expect(response).to be_success
+      parsed_response = JSON.parse(response.body)
+      expect(parsed_response["companies"].first["name"]).to eq(abc.name)
+      expect(parsed_response["companies"].second["name"]).to eq(penelope.name)
     end
   end
 end


### PR DESCRIPTION
This PR accomplishes the following:

* Defines an endpoint for `/api/v1/companies/alphabetically` that points to the `Api::V1::CompaniesController`'s alphabetically action
* Defines `alphabetically` endpoint that returns sorted companies as JSON
* Write `.sort_alphabetically` method in `Company` model to sort data by name
* Write a request spec for the endpoint
* Write model spec for `.sort_alphabetically`