### PR TITLE
Companies modern plan api

### DIFF
--- a/app/controllers/api/v1/companies_controller.rb
+++ b/app/controllers/api/v1/companies_controller.rb
@@ -8,4 +8,9 @@ class Api::V1::CompaniesController < ApplicationController
     companies = Company.sort_alphabetically
     render json: {companies: companies}
   end
+
+  def with_modern_plan
+    companies = Company.with_modern_plan
+    render json: {companies: companies}
+  end
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -8,4 +8,8 @@ class Company < ApplicationRecord
   def self.sort_alphabetically
     order(:name)
   end
+
+  def self.with_modern_plan
+    where.not(plan_level: ["legacy", "custom"])
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :companies, only: [:index]
       get "/companies/alphabetically" => "companies#alphabetically"
+      get "/companies/with_modern_plan" => "companies#with_modern_plan"
     end
   end
 end

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -14,4 +14,14 @@ describe Company do
       expect(Company.sort_alphabetically).to eq([abc, penelope, zebra])
     end
   end
+
+  describe ".with_modern_plan" do
+    it "returns a list of companies with a modern plan" do
+      penelope = Company.create!(name: "Penelope's", plan_level: "enterprise")
+      abc = Company.create!(name: "ABC's", plan_level: "basic")
+      zebra = Company.create!(name: "Zebra Company", plan_level: "legacy")
+
+      expect(Company.with_modern_plan).to include(abc, penelope)
+    end
+  end
 end

--- a/spec/requests/api/v1/companies_controller_spec.rb
+++ b/spec/requests/api/v1/companies_controller_spec.rb
@@ -27,4 +27,17 @@ describe "CompaniesController" do
       expect(parsed_response["companies"].second["name"]).to eq(penelope.name)
     end
   end
+
+  describe "GET /api/v1/companies/with_modern_plan" do
+    it "returns a list of companies sorted alphabetically by name" do
+      penelope = Company.create!(name: "Penelope's Shop", plan_level: "enterprise")
+      abc = Company.create!(name: "ABC's Shop", plan_level: "legacy")
+
+      get "/api/v1/companies/with_modern_plan"
+
+      expect(response).to be_success
+      parsed_response = JSON.parse(response.body)
+      expect(parsed_response["companies"].length).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
This PR accomplishes the following:

* Adds endpoint for returning companies with a "modern" plan level
* Adds `with_modern_plan` method to `Company` model
* Adds request and model specs