### PR TITLE
Companies not trialing api

### DIFF
--- a/app/controllers/api/v1/companies_controller.rb
+++ b/app/controllers/api/v1/companies_controller.rb
@@ -13,4 +13,9 @@ class Api::V1::CompaniesController < ApplicationController
     companies = Company.with_modern_plan
     render json: {companies: companies}
   end
+
+  def not_trialing
+    companies = Company.not_trialing
+    render json: {companies: companies}
+  end
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -12,4 +12,8 @@ class Company < ApplicationRecord
   def self.with_modern_plan
     where.not(plan_level: ["legacy", "custom"])
   end
+
+  def self.not_trialing
+    where("trial_status < ?", Time.current)
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
       resources :companies, only: [:index]
       get "/companies/alphabetically" => "companies#alphabetically"
       get "/companies/with_modern_plan" => "companies#with_modern_plan"
+      get "/companies/not_trialing" => "companies#not_trialing"
     end
   end
 end

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -24,4 +24,14 @@ describe Company do
       expect(Company.with_modern_plan).to include(abc, penelope)
     end
   end
+
+  describe ".not_trialing" do
+    it "returns a list of companies with a modern plan" do
+      penelope = Company.create!(name: "Penelope's", plan_level: "enterprise", trial_status: 2.days.from_now)
+      abc = Company.create!(name: "ABC's", plan_level: "basic", trial_status: 5.days.from_now)
+      zebra = Company.create!(name: "Zebra Company", plan_level: "legacy", trial_status: 2.days.ago)
+
+      expect(Company.not_trialing.length).to eq(1)
+    end
+  end
 end

--- a/spec/requests/api/v1/companies_controller_spec.rb
+++ b/spec/requests/api/v1/companies_controller_spec.rb
@@ -40,4 +40,18 @@ describe "CompaniesController" do
       expect(parsed_response["companies"].length).to eq(1)
     end
   end
+
+  describe "GET /api/v1/companies/not_trialing" do
+    it "returns a list of companies that are not currently trialing" do
+      penelope = Company.create!(name: "Penelope's Shop", plan_level: "enterprise", trial_status: 2.days.from_now)
+      abc = Company.create!(name: "ABC's Shop", plan_level: "legacy", trial_status: 5.days.ago)
+      zebra = Company.create!(name: "Zebra's Shop", plan_level: "legacy", trial_status: 2.days.ago)
+
+      get "/api/v1/companies/not_trialing"
+
+      expect(response).to be_success
+      parsed_response = JSON.parse(response.body)
+      expect(parsed_response["companies"].length).to eq(2)
+    end
+  end
 end

--- a/spec/requests/api/v1/companies_controller_spec.rb
+++ b/spec/requests/api/v1/companies_controller_spec.rb
@@ -29,7 +29,7 @@ describe "CompaniesController" do
   end
 
   describe "GET /api/v1/companies/with_modern_plan" do
-    it "returns a list of companies sorted alphabetically by name" do
+    it "returns a list of companies with a modern plan" do
       penelope = Company.create!(name: "Penelope's Shop", plan_level: "enterprise")
       abc = Company.create!(name: "ABC's Shop", plan_level: "legacy")
 


### PR DESCRIPTION
This PR accomplishes the following:

* Adds endpoint for returning companies that are not current trialing (as defined in the first challenge - companies who have a trial date in the past)
* Adds `not_trialing` method to `Company` model
* Adds request and model specs for the above