### PR TITLE
Companies created last month api

### DIFF
--- a/app/controllers/api/v1/companies_controller.rb
+++ b/app/controllers/api/v1/companies_controller.rb
@@ -18,4 +18,9 @@ class Api::V1::CompaniesController < ApplicationController
     companies = Company.not_trialing
     render json: {companies: companies}
   end
+
+  def created_last_month
+    companies = Company.created_last_month
+    render json: {companies: companies}
+  end
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -16,4 +16,8 @@ class Company < ApplicationRecord
   def self.not_trialing
     where("trial_status < ?", Time.current)
   end
+
+  def self.created_last_month
+    where("created_at > ? AND created_at < ?", Date.today.last_month.beginning_of_month, Date.today.beginning_of_month )
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
       get "/companies/alphabetically" => "companies#alphabetically"
       get "/companies/with_modern_plan" => "companies#with_modern_plan"
       get "/companies/not_trialing" => "companies#not_trialing"
+      get "/companies/created_last_month" => "companies#created_last_month"
     end
   end
 end

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -26,12 +26,22 @@ describe Company do
   end
 
   describe ".not_trialing" do
-    it "returns a list of companies with a modern plan" do
+    it "returns a list of companies that are not trialing" do
       penelope = Company.create!(name: "Penelope's", plan_level: "enterprise", trial_status: 2.days.from_now)
       abc = Company.create!(name: "ABC's", plan_level: "basic", trial_status: 5.days.from_now)
       zebra = Company.create!(name: "Zebra Company", plan_level: "legacy", trial_status: 2.days.ago)
 
       expect(Company.not_trialing.length).to eq(1)
+    end
+  end
+
+  describe ".created_last_month" do
+    it "returns a list of companies created last month" do
+      penelope = Company.create!(name: "Penelope's", plan_level: "enterprise", trial_status: 2.days.from_now, created_at: 1.month.ago)
+      abc = Company.create!(name: "ABC's", plan_level: "basic", trial_status: 5.days.from_now, created_at: 2.months.ago)
+      zebra = Company.create!(name: "Zebra Company", plan_level: "legacy", trial_status: Time.current)
+
+      expect(Company.created_last_month).to include(penelope)
     end
   end
 end

--- a/spec/requests/api/v1/companies_controller_spec.rb
+++ b/spec/requests/api/v1/companies_controller_spec.rb
@@ -54,4 +54,18 @@ describe "CompaniesController" do
       expect(parsed_response["companies"].length).to eq(2)
     end
   end
+
+  describe "GET /api/v1/companies/created_last_month" do
+    it "returns a list of companies that were created_last_month" do
+      penelope = Company.create!(name: "Penelope's", plan_level: "enterprise", trial_status: 2.days.from_now, created_at: 1.month.ago)
+      abc = Company.create!(name: "ABC's", plan_level: "basic", trial_status: 5.days.from_now, created_at: 2.months.ago)
+      zebra = Company.create!(name: "Zebra Company", plan_level: "legacy", trial_status: Time.current)
+
+      get "/api/v1/companies/created_last_month"
+
+      expect(response).to be_success
+      parsed_response = JSON.parse(response.body)
+      expect(parsed_response["companies"].length).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
This PR accomplishes the following:

* Adds endpoint for returning companies that were created last month
* Adds `created_last_month` method to `Company` model
* Adds request and model specs for the above